### PR TITLE
feat: made `MapDiffsToSTring` more descriptive of changes

### DIFF
--- a/datasetDiffer.go
+++ b/datasetDiffer.go
@@ -186,43 +186,101 @@ func DiffJSON(a, b []byte) (diff.Diff, error) {
 //   3. dataset.Transform
 //   4. dataset.Meta
 //   5. Dataset.VisConfig
+// func MapDiffsToString(m map[string]diff.Diff) string {
+// 	if m["structure"] != nil {
+// 		structureDiffs := m["structure"]
+// 		deltas := structureDiffs.Deltas()
+// 		if len(deltas) > 0 {
+// 			// for i, d := range deltas {
+// 			// 	fmt.Printf("%d. %s: (%T)\n", i+1, d)
+// 			// }
+// 			return fmt.Sprintf("Structure Changed. (%d changes)", len(deltas))
+// 		}
+// 	}
+// 	if m["data"] != nil {
+// 		dataDiffs := m["data"]
+// 		deltas := dataDiffs.Deltas()
+// 		if len(deltas) > 0 {
+// 			return fmt.Sprintf("Data Changed. (%d changes)", len(deltas))
+// 		}
+// 	}
+// 	if m["transform"] != nil {
+// 		transformDiffs := m["transform"]
+// 		deltas := transformDiffs.Deltas()
+// 		if len(deltas) > 0 {
+// 			return fmt.Sprintf("Transform Changed. (%d changes)", len(deltas))
+// 		}
+// 	}
+// 	if m["meta"] != nil {
+// 		metaDiffs := m["meta"]
+// 		deltas := metaDiffs.Deltas()
+// 		if len(deltas) > 0 {
+// 			return fmt.Sprintf("Metadata Changed. (%d changes)", len(deltas))
+// 		}
+// 	}
+// 	if m["visConfig"] != nil {
+// 		visConfigDiffs := m["visConfig"]
+// 		deltas := visConfigDiffs.Deltas()
+// 		if len(deltas) > 0 {
+// 			return fmt.Sprintf("VisConfig Changed. (%d changes)", len(deltas))
+// 		}
+// 	}
+// 	return ""
+// }
 func MapDiffsToString(m map[string]diff.Diff) string {
 	if m["structure"] != nil {
 		structureDiffs := m["structure"]
 		deltas := structureDiffs.Deltas()
 		if len(deltas) > 0 {
-			// for i, d := range deltas {
-			// 	fmt.Printf("%d. %s: (%T)\n", i+1, d)
-			// }
-			return fmt.Sprintf("Structure Changed. (%d changes)", len(deltas))
+			namedDiffs := ""
+			for _, d := range deltas {
+				namedDiffs = namedDiffs + fmt.Sprintf("\n\t- modified %s", d)
+			}
+			return fmt.Sprintf("Structure: %d changes%s", len(deltas), namedDiffs)
 		}
 	}
 	if m["data"] != nil {
 		dataDiffs := m["data"]
 		deltas := dataDiffs.Deltas()
 		if len(deltas) > 0 {
-			return fmt.Sprintf("Data Changed. (%d changes)", len(deltas))
+			namedDiffs := ""
+			for _, d := range deltas {
+				namedDiffs = namedDiffs + fmt.Sprintf("\n\t- modified %s", d)
+			}
+			return fmt.Sprintf("Data: %d changes%s", len(deltas), namedDiffs)
 		}
 	}
 	if m["transform"] != nil {
 		transformDiffs := m["transform"]
 		deltas := transformDiffs.Deltas()
 		if len(deltas) > 0 {
-			return fmt.Sprintf("Transform Changed. (%d changes)", len(deltas))
+			namedDiffs := ""
+			for _, d := range deltas {
+				namedDiffs = namedDiffs + fmt.Sprintf("\n\t- modified %s", d)
+			}
+			return fmt.Sprintf("Transform: %d changes%s", len(deltas), namedDiffs)
 		}
 	}
 	if m["meta"] != nil {
 		metaDiffs := m["meta"]
 		deltas := metaDiffs.Deltas()
 		if len(deltas) > 0 {
-			return fmt.Sprintf("Metadata Changed. (%d changes)", len(deltas))
+			namedDiffs := ""
+			for _, d := range deltas {
+				namedDiffs = namedDiffs + fmt.Sprintf("\n\t- modified %s", d)
+			}
+			return fmt.Sprintf("Meta: %d changes%s", len(deltas), namedDiffs)
 		}
 	}
 	if m["visConfig"] != nil {
 		visConfigDiffs := m["visConfig"]
 		deltas := visConfigDiffs.Deltas()
 		if len(deltas) > 0 {
-			return fmt.Sprintf("VisConfig Changed. (%d changes)", len(deltas))
+			namedDiffs := ""
+			for _, d := range deltas {
+				namedDiffs = namedDiffs + fmt.Sprintf("\n\t- modified %s", d)
+			}
+			return fmt.Sprintf("VisConfig: %d changes%s", len(deltas), namedDiffs)
 		}
 	}
 	return ""

--- a/datasetDiffer_test.go
+++ b/datasetDiffer_test.go
@@ -34,10 +34,10 @@ func TestDiffDataset(t *testing.T) {
 		expected                string
 		err                     string
 	}{
-		{"testdata/orig.json", "testdata/newStructure.json", "Structure Changed. (3 changes)", ""},
-		{"testdata/orig.json", "testdata/newTitle.json", "Metadata Changed. (1 changes)", ""},
-		{"testdata/orig.json", "testdata/newDescription.json", "Metadata Changed. (1 changes)", ""},
-		{"testdata/orig.json", "testdata/newVisConfig.json", "VisConfig Changed. (1 changes)", ""},
+		{"testdata/orig.json", "testdata/newStructure.json", "Structure: 3 changes\n\t- modified checksum\n\t- modified entries\n\t- modified schema", ""},
+		{"testdata/orig.json", "testdata/newTitle.json", "Meta: 1 changes\n\t- modified title", ""},
+		{"testdata/orig.json", "testdata/newDescription.json", "Meta: 1 changes\n\t- modified description", ""},
+		{"testdata/orig.json", "testdata/newVisConfig.json", "VisConfig: 1 changes\n\t- modified format", ""},
 		// {"testdata/orig.json", "testdata/newTransform.json", "Transform Changed. (1 changes)", ""},
 		// {"testdata/orig.json", "testdata/newData.json", "Data Changed. (1 changes)", ""},
 	}
@@ -64,17 +64,15 @@ func TestDiffDataset(t *testing.T) {
 			}
 		}
 		stringDiffs := MapDiffsToString(got)
-		if i == 4 {
-			// for k, v := range got {
-			// 	fmt.Printf("%s: %s\n---\n", k, v)
-			// }
-			if dsLeft.Transform == nil {
-				fmt.Println("left transform nil")
-			}
-			if dsRight.Transform == nil {
-				fmt.Println("right transform nil")
-			}
-		}
+		// if i == 0 {
+		// 	s, err := MapDiffsToFormattedString(got, dsLeft)
+		// 	if err != nil {
+		// 		t.Errorf("not today: %s", err.Error())
+		// 	}
+		// 	fmt.Println("--------------------------")
+		// 	fmt.Print(s)
+		// 	fmt.Println("--------------------------")
+		// }
 
 		if stringDiffs != c.expected {
 			t.Errorf("case %d response mistmatch: expected '%s', got '%s'", i, c.expected, stringDiffs)


### PR DESCRIPTION
now will print something like 
```bash
Structure: 3 changes
    - modified checksum
    - modified entries
    - modified schema
```
instead of just
```bash
Structure Changed. (3 changes)
```
much more progress to be made but at least a step in the right direction