### PR TITLE
fix(Differ): removed early bail that was preventing structure changes from being recognized

### DIFF
--- a/datasetDiffer.go
+++ b/datasetDiffer.go
@@ -83,18 +83,6 @@ func (d *SubDiff) SummarizeToString(how string) (string, error) {
 // DiffStructure diffs the structure of two datasets
 func DiffStructure(a, b *dataset.Structure) (*SubDiff, error) {
 	var emptyDiff = &SubDiff{kind: "structure"}
-	// if len(a.Path().String()) > 1 && len(b.Path().String()) > 1 {
-	// 	if a.Path() == b.Path() {
-	// 		return emptyDiff, nil
-	// 	}
-	// }
-	// if len(a.Checksum) > 1 && len(b.Checksum) > 1 {
-	// 	if a.Checksum == b.Checksum {
-	// 		return emptyDiff, nil
-	// 	}
-	// }
-	// If we couldn't determine that there were no changes  using the
-	// path or checksum...
 	aBytes, err := a.MarshalJSONObject()
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling structure a: %s", err.Error())

--- a/datasetDiffer.go
+++ b/datasetDiffer.go
@@ -83,16 +83,16 @@ func (d *SubDiff) SummarizeToString(how string) (string, error) {
 // DiffStructure diffs the structure of two datasets
 func DiffStructure(a, b *dataset.Structure) (*SubDiff, error) {
 	var emptyDiff = &SubDiff{kind: "structure"}
-	if len(a.Path().String()) > 1 && len(b.Path().String()) > 1 {
-		if a.Path() == b.Path() {
-			return emptyDiff, nil
-		}
-	}
-	if len(a.Checksum) > 1 && len(b.Checksum) > 1 {
-		if a.Checksum == b.Checksum {
-			return emptyDiff, nil
-		}
-	}
+	// if len(a.Path().String()) > 1 && len(b.Path().String()) > 1 {
+	// 	if a.Path() == b.Path() {
+	// 		return emptyDiff, nil
+	// 	}
+	// }
+	// if len(a.Checksum) > 1 && len(b.Checksum) > 1 {
+	// 	if a.Checksum == b.Checksum {
+	// 		return emptyDiff, nil
+	// 	}
+	// }
 	// If we couldn't determine that there were no changes  using the
 	// path or checksum...
 	aBytes, err := a.MarshalJSONObject()

--- a/datasetDiffer_test.go
+++ b/datasetDiffer_test.go
@@ -73,7 +73,7 @@ func TestDiffDataset(t *testing.T) {
 		{"testdata/orig.json", "testdata/newVisConfig.json", "plusMinus", ` {
 -  "format": "abc",
 +  "format": "new thing",
-   "kind": "vc:0"
+   "qri": "vc:0"
  }
 `, ""},
 		{"testdata/orig.json", "testdata/newTransform.json", "simple", "Transform Changed. (4 changes)", ""},

--- a/datasetDiffer_test.go
+++ b/datasetDiffer_test.go
@@ -73,7 +73,7 @@ func TestDiffDataset(t *testing.T) {
 		{"testdata/orig.json", "testdata/newVisConfig.json", "plusMinus", ` {
 -  "format": "abc",
 +  "format": "new thing",
-   "qri": "vc:0"
+   "kind": "vc:0"
  }
 `, ""},
 		{"testdata/orig.json", "testdata/newTransform.json", "simple", "Transform Changed. (4 changes)", ""},


### PR DESCRIPTION
commented out steps that prevent a comparison from happening in DiffStructure if the checksum or path have not yet been updated (as is the case when DiffDataset is called inside prepare dataset)